### PR TITLE
Feature: Allow Multiple Switchable Prometheus Data Sources

### DIFF
--- a/prometheus/capacity.json
+++ b/prometheus/capacity.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
   "__requires": [
     {
       "type": "grafana",
@@ -1495,7 +1485,20 @@
     "kubernetes"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+         "hide": 0,
+         "includeAll": false,
+         "label": "Prometheus",
+         "multi": false,
+         "name": "DS_PROMETHEUS",
+         "options": [],
+         "query": "prometheus",
+         "refresh": 1,
+         "skipUrlSync": false,
+         "type": "datasource"
+       }
+    ]
   },
   "time": {
     "from": "now-24h",


### PR DESCRIPTION
Instead of hard-coding the Prometheus data-source while importing the dashboard, make it a variable that can be switched dynamically.

<img width="296" alt="Screenshot 2021-04-08 at 1 33 33 PM" src="https://user-images.githubusercontent.com/10446685/113990514-28e7be00-986f-11eb-8b54-67ff1cb5c67a.png">